### PR TITLE
v2.0.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ QQ群：17916227 [![点击加群](https://pub.idqqimg.com/wpa/images/group.png "
 
 ## 使用说明
 
-Composer:`"yurunsoft/guzzle-swoole":"~1.1"`
-
-本项目不包含 Guzzle 功能，请自行在项目中引用 Guzzle 6.x，理论上可以支持升级 Guzzle 版本而无需更新 Guzzle-Swoole！
+Composer:`"yurunsoft/guzzle-swoole":"~2.0"`
 
 ### 全局设定处理器
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Guzzle-Swoole
 
 [![Latest Version](https://img.shields.io/packagist/v/yurunsoft/guzzle-swoole.svg)](https://packagist.org/packages/yurunsoft/guzzle-swoole)
-[![Php Version](https://img.shields.io/badge/php-%3E=7.0-brightgreen.svg)](https://secure.php.net/)
+[![Php Version](https://img.shields.io/badge/php-%3E=7.1-brightgreen.svg)](https://secure.php.net/)
 [![Swoole Version](https://img.shields.io/badge/swoole-%3E=4.0.0-brightgreen.svg)](https://github.com/swoole/swoole-src)
 [![IMI License](https://img.shields.io/github/license/Yurunsoft/Guzzle-Swoole.svg)](https://github.com/Yurunsoft/Guzzle-Swoole/blob/master/LICENSE)
 
@@ -10,6 +10,8 @@
 让 Guzzle 支持 Swoole 协程，这个项目目的就是这么简单明了！
 
 Guzzle-Swoole 是 Guzzle 的处理器（Handler），并没有对 Guzzle 本身代码进行修改，理论上可以兼容后续版本。
+
+支持 Ring Handler，可以用于 `elasticsearch/elasticsearch` 等包中。
 
 QQ群：17916227 [![点击加群](https://pub.idqqimg.com/wpa/images/group.png "点击加群")](https://jq.qq.com/?_wv=1027&k=5wXf4Zq)
 
@@ -58,3 +60,9 @@ go(function(){
 ```
 
 更加详细的示例代码请看`test`目录下代码。
+
+### ElasticSearch
+
+```php
+$client = \Elasticsearch\ClientBuilder::create()->setHosts(['192.168.0.233:9200'])->setHandler(new \Yurun\Util\Swoole\Guzzle\Ring\SwooleHandler())->build();
+```

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
 	"description": "Guzzle Swoole Handler",
     "require": {
         "composer-plugin-api": "^1.0",
-        "funkjedi/composer-include-files": "^1.0"
+        "funkjedi/composer-include-files": "^1.0",
+        "yurunsoft/yurun-http": "^3.4"
     },
     "require-dev": {
         "swoft/swoole-ide-helper": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "composer-plugin-api": "^1.0",
         "funkjedi/composer-include-files": "^1.0",
         "yurunsoft/yurun-http": "^3.4",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/ringphp": "~1.0"
     },
     "require-dev": {
         "swoft/swoole-ide-helper": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "license": "MIT",
 	"description": "Guzzle Swoole Handler",
     "require": {
+        "php": ">=7.1",
         "composer-plugin-api": "^1.0",
         "funkjedi/composer-include-files": "^1.0",
         "yurunsoft/yurun-http": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
     "require": {
         "composer-plugin-api": "^1.0",
         "funkjedi/composer-include-files": "^1.0",
-        "yurunsoft/yurun-http": "^3.4"
+        "yurunsoft/yurun-http": "^3.4",
+        "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
         "swoft/swoole-ide-helper": "~2.0",
-        "guzzlehttp/guzzle": "~6.0",
         "composer/composer": "~1.0",
         "phpunit/phpunit": "^7"
     },

--- a/src/Ring/SwooleHandler.php
+++ b/src/Ring/SwooleHandler.php
@@ -139,14 +139,12 @@ class SwooleHandler
         // request
         $method = $request['http_method'] ?? 'GET';
         $url = Core::url($request);
-        var_dump($url);
         if(isset($request['client']['curl'][CURLOPT_PORT]))
         {
             $uri = new Uri($url);
             $uri = $uri->withPort($request['client']['curl'][CURLOPT_PORT]);
             $url = (string)$uri;
         }
-        var_dump($url);
         $body = Core::body($request);
         $httpRequest->url = $url;
         $httpRequest->requestBody((string)$body);
@@ -195,11 +193,6 @@ class SwooleHandler
         {
             $error = new RingException($yurunResponse->getError());
         }
-        $headers = [];
-        foreach($yurunResponse->getHeaders() as $name => $list)
-        {
-            $headers[$name] = implode(', ', $list);
-        }
         $version = $yurunResponse->getProtocolVersion();
         $status = $yurunResponse->getStatusCode();
         $reason = $yurunResponse->getReasonPhrase();
@@ -213,7 +206,7 @@ class SwooleHandler
             ],
             'transfer_stats'    =>  $transferStatus,
             'effective_url'     =>  $transferStatus['url'],
-            'headers'           =>  $headers,
+            'headers'           =>  $yurunResponse->getHeaders(),
             'version'           =>  $version,
             'status'            =>  $status,
             'reason'            =>  $reason,

--- a/src/Ring/SwooleHandler.php
+++ b/src/Ring/SwooleHandler.php
@@ -140,8 +140,16 @@ class SwooleHandler
         // request
         $method = $request['http_method'] ?? 'GET';
         $url = Core::url($request);
+        if(isset($request['client']['curl'][CURLOPT_PORT]))
+        {
+            $uri = new Uri($url);
+            $uri = $uri->withPort($request['client']['curl'][CURLOPT_PORT]);
+            $url = (string)$uri;
+        }
         $body = Core::body($request);
-        $yurunRequest = $httpRequest->buildRequest($url, $body, $method);
+        $httpRequest->url = $url;
+        $httpRequest->requestBody($body);
+        $yurunRequest = $httpRequest->buildRequest(null, null, $method);
         return YurunHttp::send($yurunRequest, Coroutine::getuid() > -1 ? \Yurun\Util\YurunHttp\Handler\Swoole::class : \Yurun\Util\YurunHttp\Handler\Curl::class);
     }
 

--- a/src/Ring/SwooleHandler.php
+++ b/src/Ring/SwooleHandler.php
@@ -122,7 +122,6 @@ class SwooleHandler
                     $httpRequest->keyPath = $value;
                     break;
                 case 'progress':
-    
                     break;
                 case 'debug':
                     break;
@@ -140,12 +139,14 @@ class SwooleHandler
         // request
         $method = $request['http_method'] ?? 'GET';
         $url = Core::url($request);
+        var_dump($url);
         if(isset($request['client']['curl'][CURLOPT_PORT]))
         {
             $uri = new Uri($url);
             $uri = $uri->withPort($request['client']['curl'][CURLOPT_PORT]);
             $url = (string)$uri;
         }
+        var_dump($url);
         $body = Core::body($request);
         $httpRequest->url = $url;
         $httpRequest->requestBody((string)$body);

--- a/src/Ring/SwooleHandler.php
+++ b/src/Ring/SwooleHandler.php
@@ -154,6 +154,7 @@ class SwooleHandler
      */
     protected function getResponse(HttpRequest $httpRequest, Response $yurunResponse)
     {
+        $uri = new Uri($httpRequest->url);
         $transferStatus = [
             'url'                       =>  $httpRequest->url,
             'content_type'              =>  $yurunResponse->getHeaderLine('content_type'),
@@ -175,6 +176,11 @@ class SwooleHandler
             'upload_content_length'     =>  0,
             'starttransfer_time'        =>  0,
             'redirect_time'             =>  0,
+            'certinfo'                  =>  '',
+            'primary_ip'                =>  $uri->getHost(),
+            'primary_port'              =>  Uri::getServerPort($uri),
+            'local_ip'                  =>  '127.0.0.1',
+            'local_port'                =>  12345,
         ];
         if(!$yurunResponse->success)
         {

--- a/src/Ring/SwooleHandler.php
+++ b/src/Ring/SwooleHandler.php
@@ -1,0 +1,206 @@
+<?php
+namespace Yurun\Util\Swoole\Guzzle\Ring;
+
+use Swoole\Coroutine;
+use GuzzleHttp\Ring\Core;
+use Yurun\Util\YurunHttp;
+use Yurun\Util\HttpRequest;
+use Yurun\Util\YurunHttp\Http\Psr7\Uri;
+use Yurun\Util\YurunHttp\Http\Response;
+use GuzzleHttp\Ring\Exception\RingException;
+use GuzzleHttp\Ring\Future\CompletedFutureArray;
+
+class SwooleHandler
+{
+    /**
+     * 选项集合
+     *
+     * @var array
+     */
+    protected $options;
+
+    public function __construct(array $options = [])
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * @param array $request
+     *
+     * @return CompletedFutureArray
+     */
+    public function __invoke(array $request)
+    {
+        $httpRequest = new HttpRequest;
+        $yurunResponse = $this->getYurunResponse($httpRequest, $request);
+        return $this->getResponse($httpRequest, $yurunResponse);
+    }
+
+    /**
+     * 获取 YurunHttp Response
+     *
+     * @param \Yurun\Util\HttpRequest $httpRequest
+     * @param array $request
+     * @return \Yurun\Util\YurunHttp\Http\Response
+     */
+    protected function getYurunResponse(HttpRequest $httpRequest, array $request)
+    {
+        foreach ($request['client'] ?? [] as $key => $value)
+        {
+            switch ($key)
+            {
+                // Violating PSR-4 to provide more room.
+                case 'verify':
+                    if($httpRequest->isVerifyCA = $value && is_string($value))
+                    {
+                        if (!file_exists($value))
+                        {
+                            throw new \InvalidArgumentException(
+                                "SSL CA bundle not found: $value"
+                            );
+                        }
+                        $httpRequest->caCert = $value;
+                    }
+                    break;
+                case 'decode_content':
+                    break;
+                case 'save_to':
+                    break;
+                case 'timeout':
+                    $httpRequest->timeout = $value * 1000;
+                    break;
+                case 'connect_timeout':
+                    $httpRequest->connectTimeout = $value * 1000;
+                    break;
+                case 'proxy':
+                    if (!is_array($value))
+                    {
+                        $uri = new Uri($value);
+                    }
+                    else if(isset($request['scheme']))
+                    {
+                        $scheme = $request['scheme'];
+                        if (isset($value[$scheme]))
+                        {
+                            $uri = new Uri($value[$scheme]);
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                    $httpRequest->proxy($uri->getHost(), $uri->getPort(), $uri->getScheme());
+                    break;
+
+                case 'cert':
+                    if (is_array($value))
+                    {
+                        $httpRequest->certPassword = $value[1];
+                        $value = $value[0];
+                    }
+                    if (!file_exists($value))
+                    {
+                        throw new \InvalidArgumentException(
+                            "SSL certificate not found: {$value}"
+                        );
+                    }
+                    $httpRequest->certType = $value;
+                    break;
+                case 'ssl_key':
+                    if (is_array($value)) {
+                        $httpRequest->keyPassword = $value[1];
+                        // $options[CURLOPT_SSLKEYPASSWD] = $value[1];
+                        $value = $value[0];
+                    }
+    
+                    if (!file_exists($value)) {
+                        throw new \InvalidArgumentException(
+                            "SSL private key not found: {$value}"
+                        );
+                    }
+                    $httpRequest->keyPath = $value;
+                    break;
+                case 'progress':
+    
+                    break;
+                case 'debug':
+                    break;
+            }
+        }
+        // headers
+        foreach($request['headers'] as $name => $list)
+        {
+            $httpRequest->header($name, implode(', ', $list));
+        }
+        if(isset($httpRequest->headers['Content-Length']))
+        {
+            unset($httpRequest->headers['Content-Length']);
+        }
+        // request
+        $method = $request['http_method'] ?? 'GET';
+        $url = Core::url($request);
+        $body = Core::body($request);
+        $yurunRequest = $httpRequest->buildRequest($url, $body, $method);
+        return YurunHttp::send($yurunRequest, Coroutine::getuid() > -1 ? \Yurun\Util\YurunHttp\Handler\Swoole::class : \Yurun\Util\YurunHttp\Handler\Curl::class);
+    }
+
+    /**
+     * 获取响应数组
+     *
+     * @param \Yurun\Util\HttpRequest $httpRequest
+     * @param \Yurun\Util\YurunHttp\Http\Response $yurunResponse
+     * @return array
+     */
+    protected function getResponse(HttpRequest $httpRequest, Response $yurunResponse)
+    {
+        $transferStatus = [
+            'url'                       =>  $httpRequest->url,
+            'content_type'              =>  $yurunResponse->getHeaderLine('content_type'),
+            'http_code'                 =>  $yurunResponse->getStatusCode(),
+            'header_size'               =>  0,
+            'request_size'              =>  0,
+            'filetime'                  =>  0,
+            'ssl_verify_result'         =>  true,
+            'redirect_count'            =>  0,
+            'total_time'                =>  $yurunResponse->totalTime(),
+            'namelookup_time'           =>  0,
+            'connect_time'              =>  0,
+            'pretransfer_time'          =>  0,
+            'size_upload'               =>  0,
+            'size_download'             =>  0,
+            'speed_download'            =>  0,
+            'speed_upload'              =>  0,
+            'download_content_length'   =>  0,
+            'upload_content_length'     =>  0,
+            'starttransfer_time'        =>  0,
+            'redirect_time'             =>  0,
+        ];
+        if(!$yurunResponse->success)
+        {
+            $error = new RingException($yurunResponse->getError());
+        }
+        $headers = [];
+        foreach($yurunResponse->getHeaders() as $name => $list)
+        {
+            $headers[$name] = implode(', ', $list);
+        }
+        $version = $yurunResponse->getProtocolVersion();
+        $status = $yurunResponse->getStatusCode();
+        $reason = $yurunResponse->getReasonPhrase();
+        $body = (string)$yurunResponse->getBody();
+        $response = [
+            'transfer_stats'    =>  $transferStatus,
+            'headers'           =>  $headers,
+            'version'           =>  $version,
+            'status'            =>  $status,
+            'reason'            =>  $reason,
+            'body'              =>  $body,
+        ];
+        if(isset($error))
+        {
+            $response['error'] = $error;
+        }
+        return $response;
+    }
+
+}

--- a/src/Ring/SwooleHandler.php
+++ b/src/Ring/SwooleHandler.php
@@ -192,7 +192,12 @@ class SwooleHandler
         fwrite($body, (string)$yurunResponse->getBody());
         fseek($body, 0);
         $response = [
+            'curl' => [
+                'errno' => 0,
+                'error' => '',
+            ],
             'transfer_stats'    =>  $transferStatus,
+            'effective_url'     =>  $transferStatus['url'],
             'headers'           =>  $headers,
             'version'           =>  $version,
             'status'            =>  $status,

--- a/src/Ring/SwooleHandler.php
+++ b/src/Ring/SwooleHandler.php
@@ -148,7 +148,7 @@ class SwooleHandler
         }
         $body = Core::body($request);
         $httpRequest->url = $url;
-        $httpRequest->requestBody($body);
+        $httpRequest->requestBody((string)$body);
         $yurunRequest = $httpRequest->buildRequest(null, null, $method);
         return YurunHttp::send($yurunRequest, Coroutine::getuid() > -1 ? \Yurun\Util\YurunHttp\Handler\Swoole::class : \Yurun\Util\YurunHttp\Handler\Curl::class);
     }

--- a/src/Ring/SwooleHandler.php
+++ b/src/Ring/SwooleHandler.php
@@ -188,7 +188,8 @@ class SwooleHandler
         $version = $yurunResponse->getProtocolVersion();
         $status = $yurunResponse->getStatusCode();
         $reason = $yurunResponse->getReasonPhrase();
-        $body = (string)$yurunResponse->getBody();
+        $body = $yurunResponse->getBody();
+        $body->rewind();
         $response = [
             'transfer_stats'    =>  $transferStatus,
             'headers'           =>  $headers,

--- a/src/Ring/SwooleHandler.php
+++ b/src/Ring/SwooleHandler.php
@@ -33,7 +33,8 @@ class SwooleHandler
     {
         $httpRequest = new HttpRequest;
         $yurunResponse = $this->getYurunResponse($httpRequest, $request);
-        return $this->getResponse($httpRequest, $yurunResponse);
+        $response = $this->getResponse($httpRequest, $yurunResponse);
+        return new CompletedFutureArray($response);
     }
 
     /**

--- a/src/Ring/SwooleHandler.php
+++ b/src/Ring/SwooleHandler.php
@@ -188,8 +188,9 @@ class SwooleHandler
         $version = $yurunResponse->getProtocolVersion();
         $status = $yurunResponse->getStatusCode();
         $reason = $yurunResponse->getReasonPhrase();
-        $body = $yurunResponse->getBody();
-        $body->rewind();
+        $body = fopen('php://temp', 'r+');
+        fwrite($body, (string)$yurunResponse->getBody());
+        fseek($body, 0);
         $response = [
             'transfer_stats'    =>  $transferStatus,
             'headers'           =>  $headers,

--- a/src/Ring/SwooleHandler.php
+++ b/src/Ring/SwooleHandler.php
@@ -164,7 +164,7 @@ class SwooleHandler
         $uri = new Uri($httpRequest->url);
         $transferStatus = [
             'url'                       =>  $httpRequest->url,
-            'content_type'              =>  $yurunResponse->getHeaderLine('content_type'),
+            'content_type'              =>  $yurunResponse->getHeaderLine('content-type'),
             'http_code'                 =>  $yurunResponse->getStatusCode(),
             'header_size'               =>  0,
             'request_size'              =>  0,

--- a/src/SwooleHandler.php
+++ b/src/SwooleHandler.php
@@ -1,28 +1,15 @@
 <?php
 namespace Yurun\Util\Swoole\Guzzle;
 
-use GuzzleHttp\RequestOptions;
-use Swoole\Coroutine\Http\Client;
+use Yurun\Util\YurunHttp;
+use Yurun\Util\YurunHttp\Attributes;
 use Psr\Http\Message\RequestInterface;
+use Yurun\Util\YurunHttp\Http\Psr7\Uri;
 use GuzzleHttp\Promise\FulfilledPromise;
-use GuzzleHttp\Psr7\Uri;
+use PHPUnit\Framework\Constraint\Attribute;
 
 class SwooleHandler
 {
-    /**
-     * Swoole 协程 Http 客户端
-     *
-     * @var \Swoole\Coroutine\Http\Client
-     */
-    private $client;
-
-    /**
-     * 配置选项
-     *
-     * @var array
-     */
-    private $settings = [];
-
     /**
      * Sends an HTTP request.
      *
@@ -33,109 +20,49 @@ class SwooleHandler
      */
     public function __invoke(RequestInterface $request, array $options)
     {
-        $uri = $request->getUri();
-        $port = $uri->getPort();
-        if(null === $port)
+        $yurunRequest = new \Yurun\Util\YurunHttp\Http\Request($request->getUri(), $request->getHeaders(), (string)$request->getBody(), $request->getMethod(), $request->getProtocolVersion());
+        $yurunRequest = $yurunRequest->withoutHeader('Content-Length')
+                                     // 是否验证 CA
+                                     ->withAttribute(Attributes::IS_VERIFY_CA, $options['verify'])
+                                     // 禁止重定向
+                                     ->withAttribute(Attributes::FOLLOW_LOCATION, false)
+                                     // 超时
+                                     ->withAttribute(Attributes::TIMEOUT, $options['timeout'] ?? null)
+                                     // 连接超时
+                                     ->withAttribute(Attributes::CONNECT_TIMEOUT, $options['connect_timeout'] ?? null);
+        // 用户名密码认证处理
+        $auth = isset($options['auth']) ? $options['auth'] : [];
+        if(isset($auth[1]))
         {
-            if('https' === $uri->getScheme())
-            {
-                $port = 443;
-            }
-            else
-            {
-                $port = 80;
-            }
+            list($username, $password) = $auth;
+            $auth = base64_encode($username . ':' . $password);
+            $yurunRequest = $yurunRequest->withAddedHeader('Authorization', 'Basic ' . $auth);
         }
-
-        $this->client = new Client($uri->getHost(), $port, 'https' === $uri->getScheme());
-
-        // method
-        $this->client->setMethod($request->getMethod());
-
-        // body
-        $this->client->setData((string)$request->getBody());
-
-        // headers
-        $headers = [];
-        foreach($request->getHeaders() as $name => $value)
+        if(!$yurunRequest->hasHeader('Content-Type'))
         {
-            $headers[$name] = implode(',', $value);
+            $yurunRequest = $yurunRequest->withHeader('Content-Type', '');
         }
-        // 带有 Content-Length 时，少数奇葩服务器会无法顺利接收 post 数据
-        if(isset($headers['Content-Length']))
-        {
-            unset($headers['Content-Length']);
-        }
-        $this->client->setHeaders($headers);
-
-        // 其它处理
-        $this->parseSSL($request, $options);
-        $this->parseProxy($request, $options);
-        $this->parseNetwork($request, $options);
-
-        // 设置客户端参数
-        if(!empty($this->settings))
-        {
-            $this->client->set($this->settings);
-        }
-
-        // 发送
-        $path = $uri->getPath();
-        if('' === $path)
-        {
-            $path = '/';
-        }
-        $query = $uri->getQuery();
-        if('' !== $query)
-        {
-            $path .= '?' . $query;
-        }
-
-        $this->client->execute($path);
-
-        $response = $this->getResponse();
-
-        return new FulfilledPromise($response);
-    }
-
-    private function parseSSL(RequestInterface $request, array $options)
-    {
-        if(($verify = $options['verify']))
-        {
-            $this->settings['ssl_verify_peer'] = true;
-            if(is_string($verify))
-            {
-                $this->settings['ssl_cafile'] = $verify;
-            }
-        }
-        else
-        {
-            $this->settings['ssl_verify_peer'] = false;
-        }
-
+        // 证书
         $cert = isset($options['cert']) ? $options['cert'] : [];
         if(isset($cert[0]))
         {
-            $this->settings['ssl_cert_file'] = $cert[0];
+            $yurunRequest = $yurunRequest->withAttribute(Attributes::CERT_PATH, $cert[0]);
         }
-        else if(isset($this->settings['ssl_cert_file']))
+        if(isset($cert[1]))
         {
-            unset($this->settings['ssl_cert_file']);
+            $yurunRequest = $yurunRequest->withAttribute(Attributes::CERT_PASSWORD, $cert[1]);
         }
-
-        $key = isset($options['key']) ? $options['key'] : [];
+        // ssl_key
+        $key = isset($options['ssl_key']) ? $options['ssl_key'] : [];
         if(isset($key[0]))
         {
-            $this->settings['ssl_key_file'] = $key[0];
+            $yurunRequest = $yurunRequest->withAttribute(Attributes::KEY_PATH, $key[0]);
         }
-        else if(isset($this->settings['ssl_key_file']))
+        if(isset($key[1]))
         {
-            unset($this->settings['ssl_key_file']);
+            $yurunRequest = $yurunRequest->withAttribute(Attributes::KEY_PASSWORD, $key[1]);
         }
-    }
-
-    private function parseProxy(RequestInterface $request, array $options)
-    {
+        // 代理
         $proxy = isset($options['proxy']) ? $options['proxy'] : [];
         if(is_string($proxy))
         {
@@ -143,71 +70,50 @@ class SwooleHandler
                 'http' => $proxy,
             ];
         }
-        if(isset($proxy['no']) && \GuzzleHttp\is_host_in_noproxy($request->getUri()->getHost(), $proxy['no']))
+        if(!(isset($proxy['no']) && \GuzzleHttp\is_host_in_noproxy($request->getUri()->getHost(), $proxy['no'])))
         {
-            if(isset($this->settings['http_proxy_host']))
+            $scheme = $request->getUri()->getScheme();
+            $proxyUri = isset($proxy[$scheme]) ? $proxy[$scheme] : null;
+            if(null !== $proxyUri)
             {
-                unset($this->settings['http_proxy_host'], $this->settings['http_proxy_port'], $this->settings['http_proxy_user'], $this->settings['http_proxy_password']);
+                $proxyUri = new Uri($proxyUri);
+                $userinfo = explode(':', $proxyUri->getUserInfo());
+                if(isset($userinfo[1]))
+                {
+                    list($username, $password) = $userinfo;
+                }
+                else
+                {
+                    $username = $userinfo[0];
+                    $password = '';
+                }
+                $yurunRequest = $yurunRequest->withAttribute(Attributes::PROXY_SERVER, $proxyUri->getHost())
+                                             ->withAttribute(Attributes::PROXY_PORT, $proxyUri->getPort())
+                                             ->withAttribute(Attributes::PROXY_USERNAME, $username)
+                                             ->withAttribute(Attributes::PROXY_PASSWORD, $password);
             }
-            return;
         }
-        $scheme = $request->getUri()->getScheme();
-        $proxyUri = isset($proxy[$scheme]) ? $proxy[$scheme] : null;
-        if(null === $proxyUri)
-        {
-            if(isset($this->settings['http_proxy_host']))
-            {
-                unset($this->settings['http_proxy_host'], $this->settings['http_proxy_port'], $this->settings['http_proxy_user'], $this->settings['http_proxy_password']);
-            }
-            return;
-        }
-        $proxyUri = new Uri($proxyUri);
-        $userinfo = explode(':', $proxyUri->getUserInfo());
-        if(isset($userinfo[1]))
-        {
-            list($username, $password) = $userinfo;
-        }
-        else
-        {
-            $username = $userinfo[0];
-            $password = '';
-        }
-        $this->settings['http_proxy_host'] = $proxyUri->getHost();
-        $this->settings['http_proxy_port'] = $proxyUri->getPort();
-        $this->settings['http_proxy_user'] = $username;
-        $this->settings['http_proxy_password'] = $password;
+        // 发送请求
+        $yurunResponse = YurunHttp::send($yurunRequest, \Yurun\Util\YurunHttp\Handler\Swoole::class);
+        $response = $this->getResponse($yurunResponse);
+        return new FulfilledPromise($response);
     }
 
-    private function parseNetwork(RequestInterface &$request, array $options)
+    /**
+     * 获取 Guzzle Response
+     *
+     * @param \Yurun\Util\YurunHttp\Http\Response $yurunResponse
+     * @return \GuzzleHttp\Psr7\Response
+     */
+    private function getResponse($yurunResponse)
     {
-        // 用户名密码认证处理
-        $auth = isset($options['auth']) ? $options['auth'] : [];
-        if(isset($auth[1]))
+        $headers = [];
+        foreach($yurunResponse->getHeaders() as $name => $str)
         {
-            list($username, $password) = $auth;
-            $auth = base64_encode($username . ':' . $password);
-            $request = $request->withAddedHeader('Authorization', 'Basic ' . $auth);
+            $headers[$name] = implode(', ', $str);
         }
-        // 超时
-        if(isset($options['timeout']) && $options['timeout'] > 0)
-        {
-            $this->settings['timeout'] = $options['timeout'];
-        }
-        else
-        {
-            $this->settings['timeout'] = -1;
-        }
-    }
-
-    private function getResponse()
-    {
-        $headers = isset($this->client->headers) ? $this->client->headers : [];
-        if(isset($headers['set-cookie']))
-        {
-            $headers['set-cookie'] = $this->client->set_cookie_headers;
-        }
-        // var_dump($this->client);
-        $response = new \GuzzleHttp\Psr7\Response($this->client->statusCode, $headers, $this->client->body);
+        $response = new \GuzzleHttp\Psr7\Response($yurunResponse->getStatusCode(), $headers, $yurunResponse->getBody());
         return $response;
     }
+
 }

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -11,8 +11,7 @@
     <testsuites>
         <testsuite name="test">
             <directory>test</directory>
-            <file>DefaultHandlerHttpTest.php</file>
-            <file>*.php</file>
+            <file>test/DefaultHandlerHttpTest.php</file>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/test/RingSwooleHandlerTest.php
+++ b/tests/test/RingSwooleHandlerTest.php
@@ -1,0 +1,66 @@
+<?php
+namespace Yurun\Util\Swoole\Guzzle\Test;
+
+use Yurun\Util\Swoole\Guzzle\Ring\SwooleHandler;
+
+class RingSwooleHandlerTest extends BaseTest
+{
+    public function testGet()
+    {
+        $this->go(function(){
+            $handler = new SwooleHandler;
+            $response = $handler([
+                'http_method' => 'GET',
+                'uri' => '/get?id=1',
+                'headers' => [
+                    'host'  => ['httpbin.org'],
+                ],
+            ]);
+            $data = json_decode($response['body'], true);
+            $this->assertEquals(200, $response['transfer_stats']['http_code'] ?? null);
+            $this->assertEquals([
+                'id'    =>  '1',
+            ], $data['args'] ?? null);
+        });
+    }
+
+    public function testPost()
+    {
+        $this->go(function(){
+            $handler = new SwooleHandler;
+            $response = $handler([
+                'http_method'   => 'POST',
+                'uri'           => '/post?id=1',
+                'body'          => 'value=abcdefg',
+                'headers' => [
+                    'host'  => ['httpbin.org'],
+                ],
+            ]);
+            $data = json_decode($response['body'], true);
+            $this->assertEquals(200, $response['transfer_stats']['http_code'] ?? null);
+            $this->assertEquals([
+                'id'    =>  '1',
+            ], $data['args'] ?? null);
+            $this->assertEquals('abcdefg', $data['form']['value'] ?? null);
+        });
+    }
+
+    public function testHeader()
+    {
+        $this->go(function(){
+            $handler = new SwooleHandler;
+            $response = $handler([
+                'http_method' => 'GET',
+                'uri' => '/response-headers?freeform=123',
+                'headers' => [
+                    'host'  => ['httpbin.org'],
+                ],
+            ]);
+            $data = json_decode($response['body'], true);
+            $this->assertEquals(200, $response['transfer_stats']['http_code'] ?? null);
+            $this->assertEquals('123', $data['freeform'] ?? null);
+            $this->assertEquals('application/json', $data['Content-Type'] ?? null);
+        });
+    }
+
+}

--- a/tests/test/RingSwooleHandlerTest.php
+++ b/tests/test/RingSwooleHandlerTest.php
@@ -16,7 +16,7 @@ class RingSwooleHandlerTest extends BaseTest
                     'host'  => ['httpbin.org'],
                 ],
             ]);
-            $data = json_decode($response['body'], true);
+            $data = json_decode(stream_get_contents($response['body']), true);
             $this->assertEquals(200, $response['transfer_stats']['http_code'] ?? null);
             $this->assertEquals([
                 'id'    =>  '1',
@@ -36,7 +36,7 @@ class RingSwooleHandlerTest extends BaseTest
                     'host'  => ['httpbin.org'],
                 ],
             ]);
-            $data = json_decode($response['body'], true);
+            $data = json_decode(stream_get_contents($response['body']), true);
             $this->assertEquals(200, $response['transfer_stats']['http_code'] ?? null);
             $this->assertEquals([
                 'id'    =>  '1',
@@ -56,7 +56,7 @@ class RingSwooleHandlerTest extends BaseTest
                     'host'  => ['httpbin.org'],
                 ],
             ]);
-            $data = json_decode($response['body'], true);
+            $data = json_decode(stream_get_contents($response['body']), true);
             $this->assertEquals(200, $response['transfer_stats']['http_code'] ?? null);
             $this->assertEquals('123', $data['freeform'] ?? null);
             $this->assertEquals('application/json', $data['Content-Type'] ?? null);


### PR DESCRIPTION
* 新增 Ring Handler 支持，可以用于 `elasticsearch/elasticsearch` 等包中：

```php
$client = \Elasticsearch\ClientBuilder::create()->setHosts(['192.168.0.233:9200'])->setHandler(new \Yurun\Util\Swoole\Guzzle\Ring\SwooleHandler())->build();
```
* 无需再手动引入 guzzle

* 使用 YurunHttp 作为 Http 请求驱动，更加稳定可靠
